### PR TITLE
fix command line length (may not include terminating CR)

### DIFF
--- a/SOURCE/FDIMPLES/FDIMPLES.PAS
+++ b/SOURCE/FDIMPLES/FDIMPLES.PAS
@@ -48,7 +48,7 @@
 
 {$I QCRT.DEF}
 
-{$DEFINE USEBAT}
+{ DEFINE USEBAT}
 { DEFINE USEFAKE}
 
 program Test;

--- a/SOURCE/FDIMPLES/QCrt/PASCAL/QDOS.PAS
+++ b/SOURCE/FDIMPLES/QCrt/PASCAL/QDOS.PAS
@@ -942,7 +942,7 @@ begin
     P.EnvSeg := 0;
     P.CmdLn := @P.Params;
     P.Params := Params + #$0d;
-    P.Params[0] := Chr(Ord(P.Params[0]) - 1);
+    Dec(P.Params[0]);
     DoExec ($00, Command, P); { Load and Exec }
     (*
     DoExec ($03, Command[1], PSP); { Load Only }

--- a/SOURCE/FDIMPLES/QCrt/PASCAL/QDOS.PAS
+++ b/SOURCE/FDIMPLES/QCrt/PASCAL/QDOS.PAS
@@ -942,6 +942,7 @@ begin
     P.EnvSeg := 0;
     P.CmdLn := @P.Params;
     P.Params := Params + #$0d;
+    P.Params[0] := Chr(Ord(P.Params[0]) - 1);
     DoExec ($00, Command, P); { Load and Exec }
     (*
     DoExec ($03, Command[1], PSP); { Load Only }


### PR DESCRIPTION
For me this fixes issue #5. The terminating CR may not be included in the character count in PSP[80]. Params[0] aka. the Pascal string length becomes PSP[80], because the 128 command line bytes are copied unaltered to the PSP (at least this is what the FreeDOS kernel does):

https://github.com/FDOS/kernel/blob/1b6de0fda6a24fdbf6f523da95cc04d0fab1204f/kernel/task.c#L295

In Exec, the command may better be restricted to 127 bytes than 255, because this is the maximum that gets copied to the PSP.